### PR TITLE
Function return String, standard command (analog, digital, mode can be disabled

### DIFF
--- a/aREST.h
+++ b/aREST.h
@@ -114,6 +114,11 @@
 #define LIGHTWEIGHT 0
 #endif
 
+// Use light answer mode
+#ifndef EXPOSE_STANDARD_COMMANDS
+#define EXPOSE_STANDARD_COMMANDS 1
+#endif
+
 // Default number of max. exposed variables
 #ifndef NUMBER_VARIABLES
   #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_WILDFIRE) || defined(ESP8266) || !defined(ADAFRUIT_CC3000_H)
@@ -944,7 +949,7 @@ void process(char c){
      }
 
    }
-
+	if(EXPOSE_STANDARD_COMMANDS){
      // Digital command received ?
      if (answer.startsWith("digital")) {command = 'd';}
 
@@ -960,7 +965,7 @@ void process(char c){
       #endif
 
      }
-
+    }
      // Variable or function request received ?
      if (command == 'u') {
 
@@ -1291,13 +1296,15 @@ bool send_command(bool headers) {
   if (command == 'f') {
 
     // Execute function
-    int result = functions[value](arguments);
-
+    String result = functions[value](arguments);
     // Send feedback to client
     if (!LIGHTWEIGHT) {
-     addToBuffer(F("{\"return_value\": "));
+     addToBuffer(F("{\"return_value\": \""));
      addToBuffer(result);
-     addToBuffer(F(", "));
+     addToBuffer(F("\", "));
+	 /*addToBuffer(F("\"ciao\": \""));
+	 addToBuffer(prova);
+	 addToBuffer(F("\","));*/
      //addToBuffer(F(", \"message\": \""));
      //addToBuffer(functions_names[value]);
      //addToBuffer(F(" executed\", "));
@@ -1481,7 +1488,7 @@ void variable(char * variable_name, String *variable){
 }
 #endif
 
-void function(char * function_name, int (*f)(String)){
+void function(char * function_name, String (*f)(String)){
 
   functions_names[functions_index] = function_name;
   functions[functions_index] = f;
@@ -1916,7 +1923,7 @@ private:
 
   // Functions array
   uint8_t functions_index;
-  int (*functions[NUMBER_FUNCTIONS])(String);
+  String (*functions[NUMBER_FUNCTIONS])(String);
   char * functions_names[NUMBER_FUNCTIONS];
 
   // Memory debug


### PR DESCRIPTION
I changed the return value of a function to return a string to client so we can send json for example.
I thought that if i expose my api in internet, normal commands like analog, digital and mode, would be really insecure, so i added a define that help us to attach and detach them.